### PR TITLE
Legg til PartnerID

### DIFF
--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
@@ -16,14 +16,20 @@ fun SendInRequest.asEIFellesFormat(): EIFellesformat =
         msgHead = unmarshal(this@asEIFellesFormat.payload.toString(Charsets.UTF_8), MsgHead::class.java)
     }
 
-private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EIFellesformat.MottakenhetBlokk =
-    fellesFormatFactory.createEIFellesformatMottakenhetBlokk().apply {
+private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EIFellesformat.MottakenhetBlokk {
+    val partnerReferanse = when (sendInRequest.addressing.service) {
+        "PasientlisteForesporsel" -> sendInRequest.partnerId?.toString() ?: ""
+        else -> sendInRequest.cpaId
+    }
+
+    return fellesFormatFactory.createEIFellesformatMottakenhetBlokk().apply {
         ebXMLSamtaleId = sendInRequest.conversationId
         ebAction = sendInRequest.addressing.action
         ebService = sendInRequest.addressing.service
         ebRole = sendInRequest.addressing.from.role
         avsender = "TODO1" // Hentes fra from. Usikker på hvilket felt siden det kan være flere.
-        avsenderRef = "TODO2" // Hentet fra cert: Eksempelverdi: "SERIALNUMBER=132547698, CN=Blå &amp; Bjørnebær AS, O=Blå &amp; Bjørnebær AS, C=NO"
+        avsenderRef =
+            "TODO2" // Hentet fra cert: Eksempelverdi: "SERIALNUMBER=132547698, CN=Blå &amp; Bjørnebær AS, O=Blå &amp; Bjørnebær AS, C=NO"
         mottaksId = sendInRequest.messageId
         mottattDatotid = Instant.now().toXMLGregorianCalendar()
         ediLoggId = sendInRequest.messageId
@@ -32,9 +38,9 @@ private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EI
         herIdentifikator = sendInRequest.addressing.from.partyId.getIdentifikatorByType("HER")
         orgNummer = sendInRequest.addressing.from.partyId.getIdentifikatorByType("orgnummer", "ENH")
         meldingsType = "xml"
-        partnerReferanse = sendInRequest.partnerId?.toString() ?: ""
+        this.partnerReferanse = partnerReferanse
     }
+}
 
-private fun List<PartyId>.getIdentifikatorByType(vararg types: String) = this.firstOrNull {
-    types.contains(it.type)
-}?.value ?: "Ukjent"
+private fun List<PartyId>.getIdentifikatorByType(vararg types: String) =
+    this.firstOrNull { types.contains(it.type) }?.value ?: "Ukjent"

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
@@ -32,7 +32,7 @@ private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EI
         herIdentifikator = sendInRequest.addressing.from.partyId.getIdentifikatorByType("HER")
         orgNummer = sendInRequest.addressing.from.partyId.getIdentifikatorByType("orgnummer", "ENH")
         meldingsType = "xml"
-        partnerReferanse = sendInRequest.cpaId
+        partnerReferanse = sendInRequest.partnerId.toString()
     }
 
 private fun List<PartyId>.getIdentifikatorByType(vararg types: String) = this.firstOrNull {

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
@@ -32,7 +32,7 @@ private fun createFellesFormatMottakEnhetBlokk(sendInRequest: SendInRequest): EI
         herIdentifikator = sendInRequest.addressing.from.partyId.getIdentifikatorByType("HER")
         orgNummer = sendInRequest.addressing.from.partyId.getIdentifikatorByType("orgnummer", "ENH")
         meldingsType = "xml"
-        partnerReferanse = sendInRequest.partnerId.toString()
+        partnerReferanse = sendInRequest.partnerId?.toString() ?: ""
     }
 
 private fun List<PartyId>.getIdentifikatorByType(vararg types: String) = this.firstOrNull {

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapperTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapperTest.kt
@@ -14,7 +14,6 @@ class FellesFormatWrapperTest {
         val sendInRequest = validSendInPasientlisteRequest.value
         val fellesFormat = sendInRequest.asEIFellesFormat()
         Assertions.assertEquals(fellesFormat.mottakenhetBlokk.ebService, sendInRequest.addressing.service)
-        Assertions.assertEquals(fellesFormat.mottakenhetBlokk.partnerReferanse, sendInRequest.cpaId)
         log.info(marshal(fellesFormat))
     }
 
@@ -23,7 +22,6 @@ class FellesFormatWrapperTest {
         val sendInRequest = validSendInHarBorgerFrikortRequest.value
         val fellesFormat = sendInRequest.asEIFellesFormat()
         Assertions.assertEquals(fellesFormat.mottakenhetBlokk.ebService, sendInRequest.addressing.service)
-        Assertions.assertEquals(fellesFormat.mottakenhetBlokk.partnerReferanse, sendInRequest.cpaId)
         log.info(marshal(fellesFormat))
     }
 
@@ -32,7 +30,6 @@ class FellesFormatWrapperTest {
         val sendInRequest = validSendInInntektforesporselRequest.value
         val fellesFormat = sendInRequest.asEIFellesFormat()
         Assertions.assertEquals(fellesFormat.mottakenhetBlokk.ebService, sendInRequest.addressing.service)
-        Assertions.assertEquals(fellesFormat.mottakenhetBlokk.partnerReferanse, sendInRequest.cpaId)
         log.info(marshal(fellesFormat))
     }
 

--- a/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
+++ b/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
@@ -15,7 +15,7 @@ data class SendInRequest(
     val ebmsProcessing: EbmsProcessing,
     val signedOf: String? = null,
     val requestId: String,
-    val partnerId: Long? = null,
+    val partnerId: Long? = null
 )
 
 @Serializable

--- a/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
+++ b/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
@@ -15,7 +15,7 @@ data class SendInRequest(
     val ebmsProcessing: EbmsProcessing,
     val signedOf: String? = null,
     val requestId: String,
-    val partnerId: Long,
+    val partnerId: Long? = null,
 )
 
 @Serializable

--- a/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
+++ b/felles/src/main/kotlin/no/nav/emottak/melding/model/Model.kt
@@ -14,7 +14,8 @@ data class SendInRequest(
     val cpaId: String,
     val ebmsProcessing: EbmsProcessing,
     val signedOf: String? = null,
-    val requestId: String
+    val requestId: String,
+    val partnerId: Long,
 )
 
 @Serializable


### PR DESCRIPTION
- Har lagt partnerId slik at SendIn mottar denne hvis Service er "PasientlisteForesporsel"
- Tatt vekk falske tester (vi har ikke partnerId i XMLen, så det gir ikke meningen å teste referansen der)


Dette løser problemet med at HentPasientliste CPA ikke kunne sendes igjennom oss.

Relatert til: https://github.com/navikt/ebxml-processor/pull/114