### PR TITLE
Handle errors frikort

### DIFF
--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingService.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingService.kt
@@ -56,21 +56,21 @@ object FagmeldingService {
 
             SupportedServiceType.HarBorgerEgenandelFritak, SupportedServiceType.HarBorgerFrikort ->
                 timed(meterRegistry, "frikort-sporing") {
-                    with(sendInRequest.asEIFellesFormat()) {
-                        frikortsporring(this).let { response ->
-                            SendInResponse(
-                                messageId = sendInRequest.messageId,
-                                conversationId = sendInRequest.conversationId,
-                                addressing = sendInRequest.addressing.replyTo(
-                                    response.eiFellesformat.mottakenhetBlokk.ebService,
-                                    response.eiFellesformat.mottakenhetBlokk.ebAction
-                                ),
-                                payload = FellesFormatXmlMarshaller.marshalToByteArray(
-                                    response.eiFellesformat.msgHead
-                                ),
-                                requestId = Uuid.random().toString()
-                            )
-                        }
+                    Either.catch {
+                        frikortsporring(sendInRequest.asEIFellesFormat())
+                    }.bind().let { response ->
+                        SendInResponse(
+                            messageId = sendInRequest.messageId,
+                            conversationId = sendInRequest.conversationId,
+                            addressing = sendInRequest.addressing.replyTo(
+                                response.eiFellesformat.mottakenhetBlokk.ebService,
+                                response.eiFellesformat.mottakenhetBlokk.ebAction
+                            ),
+                            payload = FellesFormatXmlMarshaller.marshalToByteArray(
+                                response.eiFellesformat.msgHead
+                            ),
+                            requestId = Uuid.random().toString()
+                        )
                     }
                 }
 

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingService.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingService.kt
@@ -76,21 +76,21 @@ object FagmeldingService {
 
             SupportedServiceType.HarBorgerFrikortMengde ->
                 timed(meterRegistry, "frikortMengde-sporing") {
-                    with(sendInRequest.asEIFellesFormat()) {
-                        frikortsporringMengde(this).let { response ->
-                            SendInResponse(
-                                messageId = sendInRequest.messageId,
-                                conversationId = sendInRequest.conversationId,
-                                addressing = sendInRequest.addressing.replyTo(
-                                    response.eiFellesformat.mottakenhetBlokk.ebService,
-                                    response.eiFellesformat.mottakenhetBlokk.ebAction
-                                ),
-                                payload = FellesFormatXmlMarshaller.marshalToByteArray(
-                                    response.eiFellesformat.msgHead
-                                ),
-                                requestId = Uuid.random().toString()
-                            )
-                        }
+                    Either.catch {
+                        frikortsporringMengde(sendInRequest.asEIFellesFormat())
+                    }.bind().let { response ->
+                        SendInResponse(
+                            messageId = sendInRequest.messageId,
+                            conversationId = sendInRequest.conversationId,
+                            addressing = sendInRequest.addressing.replyTo(
+                                response.eiFellesformat.mottakenhetBlokk.ebService,
+                                response.eiFellesformat.mottakenhetBlokk.ebAction
+                            ),
+                            payload = FellesFormatXmlMarshaller.marshalToByteArray(
+                                response.eiFellesformat.msgHead
+                            ),
+                            requestId = Uuid.random().toString()
+                        )
                     }
                 }
 


### PR DESCRIPTION
Hindrer loggmeldinger av typen `Unhandled: POST - /fagmelding/synkron` når feil inntreffer mot fagsystemet frikort. Nå håndteres feil som definert i routen.