### PR TITLE
Legger til trekkopplysning marshaller for svarmeldinger

### DIFF
--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingResponseService.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingResponseService.kt
@@ -3,6 +3,8 @@ package no.nav.emottak.ebms.service
 import no.nav.emottak.ebms.utils.SupportedAsyncServiceType
 import no.nav.emottak.ebms.utils.SupportedAsyncServiceType.Companion.toSupportedAsyncService
 import no.nav.emottak.fellesformat.FellesFormatXmlMarshaller
+import no.nav.emottak.trekkopplysning.apprecTrekkopplysningMarshaller
+import no.nav.emottak.trekkopplysning.msgheadTrekkopplysningMarshaller
 import no.nav.emottak.util.LogLevel
 import no.nav.emottak.util.asJson
 import no.nav.emottak.utils.common.model.Addressing
@@ -50,6 +52,16 @@ object FagmeldingResponseService {
                     )
             }
 
+        val xmlMarshaller = when (fellesFormatResponse.mottakenhetBlokk.ebService.toSupportedAsyncService()) {
+            SupportedAsyncServiceType.Trekkopplysning ->
+                if (fellesFormatResponse.msgHead != null) {
+                    msgheadTrekkopplysningMarshaller
+                } else {
+                    apprecTrekkopplysningMarshaller
+                }
+            SupportedAsyncServiceType.Unsupported -> FellesFormatXmlMarshaller
+        }
+
         val response = SendInResponse(
             messageId = Uuid.random().toString(),
             refToMessageId = fellesFormatResponse.mottakenhetBlokk.ediLoggId,
@@ -61,7 +73,7 @@ object FagmeldingResponseService {
                 fellesFormatResponse.mottakenhetBlokk.ebService,
                 fellesFormatResponse.mottakenhetBlokk.ebAction
             ),
-            payload = FellesFormatXmlMarshaller.marshalToByteArray(
+            payload = xmlMarshaller.marshalToByteArray(
                 fellesFormatResponse.msgHead ?: fellesFormatResponse.appRec
             ),
             requestId = Uuid.random().toString()

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningXmlMarshaller.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningXmlMarshaller.kt
@@ -15,6 +15,22 @@ val trekkopplysningXmlMarshaller = XmlMarshaller(
     )
 )
 
+val msgheadTrekkopplysningMarshaller = XmlMarshaller(
+    newInstance(
+        no.kith.xmlstds.msghead._2006_05_24.ObjectFactory::class.java,
+        org.w3._1999.xlink.ObjectFactory::class.java,
+        org.w3._2009.xmldsig11_.ObjectFactory::class.java
+    )
+)
+
+val apprecTrekkopplysningMarshaller = XmlMarshaller(
+    newInstance(
+        no.kith.xmlstds.apprec._2004_11_21.ObjectFactory::class.java,
+        org.w3._1999.xlink.ObjectFactory::class.java,
+        org.w3._2009.xmldsig11_.ObjectFactory::class.java
+    )
+)
+
 fun marshalTrekkopplysning(fellesFormat: EIFellesformat): String {
     val writer = StringWriter()
     val xmlStreamWriter = TrekkopplysningWriter(XMLOutputFactory.newFactory().createXMLStreamWriter(writer))

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
@@ -1,0 +1,95 @@
+package no.nav.emottak.trekkopplysning
+
+import no.kith.xmlstds.apprec._2004_11_21.AppRec
+import no.kith.xmlstds.msghead._2006_05_24.MsgHead
+import no.nav.emottak.fellesformat.unmarshal
+import no.trygdeetaten.xml.eiff._1.EIFellesformat
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class TrekkopplysningMarshallerTest {
+
+    private fun loadResource(filename: String): String =
+        this::class.java.classLoader.getResourceAsStream("trekkopplysning/$filename")!!
+            .readAllBytes().toString(Charsets.UTF_8)
+
+    // kvittering contains a MsgHead inside EI_fellesformat
+
+    @Test
+    fun `kvittering - extracted MsgHead marshals to XML with correct namespace`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
+        val msgHead = fellesformat.msgHead
+
+        val xml = msgheadTrekkopplysningMarshaller.marshal(msgHead)
+
+        assertTrue(xml.contains("http://www.kith.no/xmlstds/msghead/2006-05-24"))
+        assertTrue(xml.contains("MsgHead"))
+    }
+
+    @Test
+    fun `kvittering - round-trip marshal then unmarshal preserves MsgInfo fields`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
+        val msgHead = fellesformat.msgHead
+
+        val xml = msgheadTrekkopplysningMarshaller.marshal(msgHead)
+        val restored = msgheadTrekkopplysningMarshaller.unmarshal(xml, MsgHead::class.java)
+
+        assertNotNull(restored.msgInfo)
+        assertEquals("f2f0f2f6-f0f4-f2f1-f1f3-f2f5f1f6f9f4", restored.msgInfo.msgId)
+        assertEquals("INNRAPPORTERING_TREKK_RETUR", restored.msgInfo.type.v)
+        assertEquals("v1.2 2006-05-24", restored.msgInfo.getMIGversion())
+        assertEquals("NAV IKT", restored.msgInfo.sender.organisation.organisationName)
+        assertEquals("TEST AS", restored.msgInfo.receiver.organisation.organisationName)
+    }
+
+    @Test
+    fun `kvittering - marshalToByteArray produces non-empty result containing expected MsgId`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
+        val msgHead = fellesformat.msgHead
+
+        val bytes = msgheadTrekkopplysningMarshaller.marshalToByteArray(msgHead)
+
+        assertTrue(bytes.isNotEmpty())
+        assertTrue(String(bytes).contains("f2f0f2f6-f0f4-f2f1-f1f3-f2f5f1f6f9f4"))
+    }
+
+    @Test
+    fun `print marshalled output for both files`() {
+        val kvittering = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
+        val avvisning = unmarshal(loadResource("trekkopplysning_avvisning.xml"), EIFellesformat::class.java)
+
+        println("=== kvittering (MsgHead) ===")
+        println(msgheadTrekkopplysningMarshaller.marshal(kvittering.msgHead))
+
+        println("=== avvisning (AppRec) via minimalTrekkopplysningAppRecMarshaller ===")
+        println(String(apprecTrekkopplysningMarshaller.marshalToByteArray(avvisning.appRec)))
+    }
+
+    // avvisning contains an AppRec inside EI_fellesformat
+
+    @Test
+    fun `avvisning - extracted AppRec marshals to XML containing expected elements`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_avvisning.xml"), EIFellesformat::class.java)
+        val appRec = fellesformat.appRec
+
+        val xml = String(apprecTrekkopplysningMarshaller.marshalToByteArray(appRec))
+
+        assertTrue(xml.contains("AppRec"))
+        assertTrue(xml.contains("Avvist"))
+    }
+
+    @Test
+    fun `avvisning - round-trip marshal then unmarshal preserves AppRec fields`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_avvisning.xml"), EIFellesformat::class.java)
+        val appRec = fellesformat.appRec
+
+        val xml = String(apprecTrekkopplysningMarshaller.marshalToByteArray(appRec))
+        val restored = apprecTrekkopplysningMarshaller.unmarshal(xml, AppRec::class.java)
+
+        assertEquals("f2f0f2f6-f0f5-f0f4-f1f4-f2f6f0f3f4f8", restored.id)
+        assertEquals("2", restored.status.v)
+        assertEquals("Avvist", restored.status.dn)
+    }
+}

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
@@ -16,6 +16,26 @@ class TrekkopplysningMarshallerTest {
         this::class.java.classLoader.getResourceAsStream("trekkopplysning/$filename")!!
             .readAllBytes().toString(Charsets.UTF_8)
 
+    @Test
+    fun `kvittering - top-level MsgHead element has no namespace prefix`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
+
+        val xml = msgheadTrekkopplysningMarshaller.marshal(fellesformat.msgHead)
+
+        assertTrue(xml.contains("<MsgHead "), "Expected unprefixed <MsgHead> but got:\n$xml")
+        assertTrue(xml.contains("""xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24""""), "Expected default namespace on MsgHead")
+    }
+
+    @Test
+    fun `avvisning - top-level AppRec element has no namespace prefix`() {
+        val fellesformat = unmarshal(loadResource("trekkopplysning_avvisning.xml"), EIFellesformat::class.java)
+
+        val xml = String(apprecTrekkopplysningMarshaller.marshalToByteArray(fellesformat.appRec))
+
+        assertTrue(xml.contains("<AppRec "), "Expected unprefixed <AppRec> but got:\n$xml")
+        assertTrue(xml.contains("""xmlns="http://www.kith.no/xmlstds/apprec/2004-11-21""""), "Expected default namespace on AppRec")
+    }
+
     // kvittering contains a MsgHead inside EI_fellesformat
 
     @Test

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/trekkopplysning/TrekkopplysningMarshallerTest.kt
@@ -2,6 +2,7 @@ package no.nav.emottak.trekkopplysning
 
 import no.kith.xmlstds.apprec._2004_11_21.AppRec
 import no.kith.xmlstds.msghead._2006_05_24.MsgHead
+import no.nav.emottak.fellesformat.FellesFormatXmlMarshaller
 import no.nav.emottak.fellesformat.unmarshal
 import no.trygdeetaten.xml.eiff._1.EIFellesformat
 import org.junit.jupiter.api.Test
@@ -60,10 +61,13 @@ class TrekkopplysningMarshallerTest {
         val kvittering = unmarshal(loadResource("trekkopplysning_kvittering.xml"), EIFellesformat::class.java)
         val avvisning = unmarshal(loadResource("trekkopplysning_avvisning.xml"), EIFellesformat::class.java)
 
-        println("=== kvittering (MsgHead) ===")
-        println(msgheadTrekkopplysningMarshaller.marshal(kvittering.msgHead))
+        println("=== kvittering (MsgHead) using old marshaller ===")
+        println(String(FellesFormatXmlMarshaller.marshalToByteArray(kvittering.msgHead)))
 
-        println("=== avvisning (AppRec) via minimalTrekkopplysningAppRecMarshaller ===")
+        println("=== kvittering (MsgHead) ===")
+        println(String(msgheadTrekkopplysningMarshaller.marshalToByteArray(kvittering.msgHead)))
+
+        println("=== avvisning (AppRec) via apprecTrekkopplysningMarshaller ===")
         println(String(apprecTrekkopplysningMarshaller.marshalToByteArray(avvisning.appRec)))
     }
 

--- a/ebms-send-in/src/test/resources/trekkopplysning/trekkopplysning_avvisning.xml
+++ b/ebms-send-in/src/test/resources/trekkopplysning/trekkopplysning_avvisning.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<EI_fellesformat xmlns="http://www.trygdeetaten.no/xml/eiff/1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <AppRec xmlns="http://www.kith.no/xmlstds/apprec/2004-11-21" xmlns:xsd="http://www.w3.org/2001/XMLSchema.xsd"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xsi:schemaLocation="http://www.kith.no/xmlstds/apprec/2004-11-21 AppRec-v1-2004-11-21.xsd">
+        <MsgType V="APPREC"/>
+        <MIGversion>1.0 2004-11-21</MIGversion>
+        <GenDate>2026-05-04T14:26:03</GenDate>
+        <Id>f2f0f2f6-f0f5-f0f4-f1f4-f2f6f0f3f4f8</Id>
+        <Sender>
+            <Role V="SENDER"/>
+            <HCP>
+                <Inst>
+                    <Name>NAV IKT</Name>
+                    <Id>79768</Id>
+                    <TypeId V="HER" DN="HER-id"/>
+                </Inst>
+            </HCP>
+        </Sender>
+        <Receiver>
+            <Role V="RECEIVER"/>
+            <HCP>
+                <Inst>
+                    <Name>Helseplattformen</Name>
+                    <Id>12345678</Id>
+                    <TypeId V="HER" DN="HER-id"/>
+                    <Dept>
+                        <Name>Meldingsmottak</Name>
+                        <Id>12345678</Id>
+                        <TypeId V="HER" DN="HER-id"/>
+                    </Dept>
+                </Inst>
+            </HCP>
+        </Receiver>
+        <Status V="2" DN="Avvist"/>
+        <Error S="2.16.578.1.12.4.1.1.8124" V="00000404" DN="BAQR1131E: API requester
+        Pdl-Proxy-API_1.0.0.Q1 is not reg"/>
+        <OriginalMsgId>
+            <MsgType V="INNRAPPORTERING_TREKK" DN="Innrapportering av
+        trekk, XML, v1.1"/>
+            <IssueDate>2026-05-04T14:24:55</IssueDate>
+            <Id>1a02f929-7fc9-4e27-98ff-a8f5c29803b7</Id>
+        </OriginalMsgId>
+    </AppRec>
+    <MottakenhetBlokk avsender="12345678"
+                      avsenderRef="OID.2.5.4.97=NTRNO-922307814, CN=HELSEPLATTFORMEN AS TEST, O=HELSEPLATTFORMEN AS, C=NO"
+                      ebAction="Avvisning" ebRole="Ytelsesutbetaler" ebService="Trekkopplysning"
+                      ebXMLSamtaleId="1a02f929-7fc9-4e27-98ff-a8f5c29803b7" ediLoggId="2605041426hemi32596.1"
+                      herIdentifikator="" meldingsType="xml" mottattDatotid="2026-05-04T14:26:03"
+                      partnerReferanse="17395"/>
+</EI_fellesformat>

--- a/ebms-send-in/src/test/resources/trekkopplysning/trekkopplysning_kvittering.xml
+++ b/ebms-send-in/src/test/resources/trekkopplysning/trekkopplysning_kvittering.xml
@@ -1,0 +1,98 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<EI_fellesformat xmlns="http://www.trygdeetaten.no/xml/eiff/1/">
+    <MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24">
+        <MsgInfo>
+            <Type V="INNRAPPORTERING_TREKK_RETUR" DN="Innrapportering av trekk til NAV retur"/>
+            <MIGversion>v1.2 2006-05-24</MIGversion>
+            <GenDate>2026-04-21T13:25:16</GenDate>
+            <MsgId>f2f0f2f6-f0f4-f2f1-f1f3-f2f5f1f6f9f4</MsgId>
+            <Ack V="N" DN="Nei"/>
+            <ConversationRef>
+                <RefToParent>283bc4b8-019a-4526-9912-fc2ddde2efa2</RefToParent>
+                <RefToConversation>283bc4b8-019a-4526-9912-fc2ddde2efa2</RefToConversation>
+            </ConversationRef>
+            <Sender>
+                <Organisation>
+                    <OrganisationName>NAV IKT</OrganisationName>
+                    <Ident>
+                        <Id>79768</Id>
+                        <TypeId V="HER" S="2.16.578.1.12.4.1.1.9051" DN="HER-id"/>
+                    </Ident>
+                </Organisation>
+            </Sender>
+            <Receiver>
+                <Organisation>
+                    <OrganisationName>TEST AS</OrganisationName>
+                    <Ident>
+                        <Id>12345678</Id>
+                        <TypeId V="HER" S="2.16.578.1.12.4.1.1.9051" DN="HER-id"/>
+                    </Ident>
+                    <Organisation>
+                        <OrganisationName>Økonomi og oppgjør</OrganisationName>
+                        <Ident>
+                            <Id>12345678</Id>
+                            <TypeId V="HER" S="2.16.578.1.12.4.1.1.9051" DN="HER-id"/>
+                        </Ident>
+                    </Organisation>
+                </Organisation>
+            </Receiver>
+            <Patient>
+                <FamilyName>RETNINGSLINJE</FamilyName>
+                <GivenName>KONSEKVENT</GivenName>
+                <Sex V="1" DN="Mann"/>
+                <Ident>
+                    <Id>***********</Id>
+                    <TypeId V="FNR" S="2.16.578.1.12.4.1.1.8116" DN="Fødselsnummer"/>
+                </Ident>
+            </Patient>
+        </MsgInfo>
+        <Document>
+            <ContentDescription>SV:SV:Innrapportering av trekk til NAV</ContentDescription>
+            <RefDoc>
+                <IssueDate V="2026-04-21T11:24:55Z"/>
+                <MsgType V="XML" DN="XML-instans"/>
+                <Content>
+                    <InnrapporteringTrekk
+                            xsi:schemaLocation="http://www.kith.no/xmlstds/nav/innrapporteringtrekk/2010-02-04 InnrapporteringTrekk-2010-02-04.xsd"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns="http://www.kith.no/xmlstds/nav/innrapporteringtrekk/2010-02-04"
+                            xmlns:fk1="http://www.kith.no/xmlstds/felleskomponent1">
+                        <Identifisering>
+                            <KreditorTrekkId>787e4fe2-70f0-40d1-9799-14be30fb421</KreditorTrekkId>
+                            <NavTrekkId>0014035554</NavTrekkId>
+                            <DebitorId>
+                                <fk1:Id>***********</fk1:Id>
+                                <fk1:TypeId V="FNR"/>
+                            </DebitorId>
+                        </Identifisering>
+                        <Periode>
+                            <PeriodeFomDato>2026-06-01</PeriodeFomDato>
+                        </Periode>
+                        <Kreditor>
+                            <TSSId>***********</TSSId>
+                            <OrgNr>
+                                <fk1:Id>***********</fk1:Id>
+                                <fk1:TypeId V=""/>
+                            </OrgNr>
+                            <Navn>TEST TEST</Navn>
+                            <Adresse>
+                                <fk1:StreetAdr>postboks 145</fk1:StreetAdr>
+                                <fk1:PostalCode>5701</fk1:PostalCode>
+                            </Adresse>
+                            <Ref></Ref>
+                            <Kontonr>***********</Kontonr>
+                            <KID></KID>
+                        </Kreditor>
+                    </InnrapporteringTrekk>
+                </Content>
+            </RefDoc>
+        </Document>
+    </MsgHead>
+    <MottakenhetBlokk ediLoggId="3fec5045-7c58-488f-8e47-7ad7468bb372" avsender="12345678"
+                      ebXMLSamtaleId="e2623e62-56e7-41ea-b18e-0046d1ba853f" meldingsType="xml" avsenderRef=""
+                      mottattDatotid="2026-04-21T11:25:16.872Z" orgNummer="Ukjent" partnerReferanse="nav:qass:36181"
+                      herIdentifikator="12345678" ebAction="Kvittering" ebRole="Ytelsesutbetaler"
+                      ebService="Trekkopplysning"/>
+</EI_fellesformat>
+
+


### PR DESCRIPTION
Noen rapporterer om nye namespace-prefikser på trekkopplysning-svarene. (fra  `<MsgHead>` til  `<ns7:MsgHead>`), som gjør at de ikke klarer å lese meldingene. 

Vi legger til unødvendig masse namespacer. Laget to spisse marshallere, en for MsgHead og en for AppRec, slik at output-xmlen ser litt penere ut.