### PR TITLE
Henter ut rotnoden til xml uten kommentarer

### DIFF
--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesformatXmlBuilder.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesformatXmlBuilder.kt
@@ -61,7 +61,7 @@ class FellesformatXmlBuilder {
         doc.appendChild(ffElement)
 
         val payloadDoc = f.newDocumentBuilder().parse(ByteArrayInputStream(payload))
-        val payloadElement = payloadDoc.childNodes.item(0) // MsgHead
+        val payloadElement = payloadDoc.documentElement // MsgHead - skips any leading comments/PIs
         val msgHead = doc.importNode(payloadElement, true)
         ffElement.appendChild(msgHead)
 

--- a/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesformatXmlBuilderTest.kt
+++ b/ebms-send-in/src/test/kotlin/no/nav/emottak/fellesformat/FellesformatXmlBuilderTest.kt
@@ -1,0 +1,54 @@
+package no.nav.emottak.fellesformat
+
+import no.trygdeetaten.xml.eiff._1.EIFellesformat
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.nio.charset.StandardCharsets
+
+class FellesformatXmlBuilderTest {
+
+    private val builder = FellesformatXmlBuilder()
+
+    private val mottakenhetBlokk = EIFellesformat.MottakenhetBlokk().apply {
+        ediLoggId = "1"
+        ebService = "service"
+    }
+
+    private val payloadWithoutComment =
+        """<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24"><MsgInfo/></MsgHead>"""
+
+    // Regression case: a comment before the root element is legal XML and used to make
+    // payloadDoc.childNodes.item(0) return the Comment node instead of the MsgHead element.
+    private val payloadWithLeadingComment =
+        """<?xml version="1.0" encoding="UTF-8"?>
+            |<!-- some comment -->
+            |<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24"><MsgInfo/></MsgHead>
+        """.trimMargin()
+
+    @Test
+    fun `buildFellesformatDocument extracts MsgHead as root child when payload has no leading comment`() {
+        val doc = builder.buildFellesformatDocument(mottakenhetBlokk, payloadWithoutComment.toByteArray(StandardCharsets.UTF_8))
+
+        val msgHead = doc.documentElement.firstChild
+        assertNotNull(msgHead)
+        assertEquals("MsgHead", msgHead.localName)
+    }
+
+    @Test
+    fun `buildFellesformatDocument extracts MsgHead as root child when payload has a leading comment`() {
+        val doc = builder.buildFellesformatDocument(mottakenhetBlokk, payloadWithLeadingComment.toByteArray(StandardCharsets.UTF_8))
+
+        val msgHead = doc.documentElement.firstChild
+        assertNotNull(msgHead)
+        assertEquals("MsgHead", msgHead.localName)
+    }
+
+    @Test
+    fun `buildXmlWithCustomMottakenhetBlokk produces MsgHead element when payload has a leading comment`() {
+        val xml = builder.buildXmlWithCustomMottakenhetBlokk(mottakenhetBlokk, payloadWithLeadingComment.toByteArray(StandardCharsets.UTF_8))
+
+        assertEquals(true, xml.contains("<MsgHead"))
+        assertEquals(false, xml.contains("<!--"))
+    }
+}


### PR DESCRIPTION
`childNodes.item(0)` returnerer det første barnenoden til Document-objektet, ikke nødvendigvis rot-elementet. Hvis payloaden inneholder en kommentar før MsgHead , f.eks.:

```
<?xml version="1.0" encoding="UTF-8"?>
<!-- en kommentar -->
<MsgHead xmlns="http://www.kith.no/xmlstds/msghead/2006-05-24">
    <MsgInfo/>
</MsgHead>
```

vil `childNodes.item(0)` returnere kommentar-noden i stedet for  `MsgHead`. Denne kommentaren ble da importert og lagt til i  EI_fellesformat  i stedet for det faktiske  `MsgHead`. Resultatet er en EI_fellesformat uten MsgHead, noe som fører til  `NullPointerException`  hos konsumenter som forventer å finne  `MsgHead`  i den ferdige XML-en.