### PR TITLE
Tar bort ediLoggId-prefiks for legemeldinger

### DIFF
--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/App.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/App.kt
@@ -38,13 +38,6 @@ const val USE_ASYNC_IN_KEY = "USE_ASYNC_IN"
 const val USE_ASYNC_OUT_KEY = "USE_ASYNC_OUT"
 const val USE_DOMBUILDER_TREKKOPPLYSNING_KEY = "USE_DOMBUILDER"
 
-// todo så lenge vi sender noen Legemeldinger til nye og noen til gamle eMottak,
-//  bruker vi et id-prefiks for å skille ut de som hører til nye eMottak.
-// Når dette skal fjernes:
-// 1) endre asynch-router så ALLE legemeldinger går til nye emottak, uavhengig av prefiks
-// 2) fjern prefikset under og bruken av det
-const val NYE_EMOTTAK_LEGEMELDING_ID_PREFIX = "nye-emottak-"
-
 internal val log = LoggerFactory.getLogger("no.nav.emottak.App")
 
 fun main() = SuspendApp {

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingResponseService.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/ebms/service/FagmeldingResponseService.kt
@@ -1,6 +1,5 @@
 package no.nav.emottak.ebms.service
 
-import no.nav.emottak.NYE_EMOTTAK_LEGEMELDING_ID_PREFIX
 import no.nav.emottak.ebms.utils.SupportedAsyncServiceType
 import no.nav.emottak.ebms.utils.SupportedAsyncServiceType.Companion.toSupportedAsyncService
 import no.nav.emottak.fellesformat.FellesFormatXmlMarshaller
@@ -83,12 +82,9 @@ object FagmeldingResponseService {
             SupportedAsyncServiceType.Unsupported -> FellesFormatXmlMarshaller
         }
 
-        // todo foreløpig løsning, har kun effekt for legemelding-respons
-        val refToMessageId = fellesFormatResponse.mottakenhetBlokk.ediLoggId.removePrefix(NYE_EMOTTAK_LEGEMELDING_ID_PREFIX)
-
         val response = SendInResponse(
             messageId = Uuid.random().toString(),
-            refToMessageId = refToMessageId,
+            refToMessageId = fellesFormatResponse.mottakenhetBlokk.ediLoggId,
             conversationId = fellesFormatResponse.mottakenhetBlokk.ebXMLSamtaleId ?: "",
             cpaId = fellesFormatResponse.mottakenhetBlokk.partnerReferanse ?: "",
             addressing = Addressing(

--- a/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
+++ b/ebms-send-in/src/main/kotlin/no/nav/emottak/fellesformat/FellesFormatWrapper.kt
@@ -1,7 +1,6 @@
 package no.nav.emottak.fellesformat
 
 import no.kith.xmlstds.msghead._2006_05_24.MsgHead
-import no.nav.emottak.NYE_EMOTTAK_LEGEMELDING_ID_PREFIX
 import no.nav.emottak.frikort.frikortSporringXmlMarshaller
 import no.nav.emottak.util.toXmlGregorianCalendar
 import no.nav.emottak.utils.common.model.PartyId
@@ -141,7 +140,7 @@ private fun createFellesFormatMottakEnhetBlokk_Legemelding(sendInRequest: SendIn
         avsender = sendInRequest.addressing.from.partyId.getIdentifikatorByType("HER", "ENH", "orgnummer")
         avsenderFnrFraDigSignatur = sendInRequest.signedOf ?: "NA" // todo OK?
         mottattDatotid = Instant.now().toXmlGregorianCalendar()
-        ediLoggId = NYE_EMOTTAK_LEGEMELDING_ID_PREFIX + sendInRequest.messageId
+        ediLoggId = sendInRequest.messageId
 //        meldingsType = "xml"
 //        this.partnerReferanse = sendInRequest.cpaId
         avsenderRef = "" // todo OK?

--- a/ebms-send-in/src/test/resources/legemelding.xml
+++ b/ebms-send-in/src/test/resources/legemelding.xml
@@ -128,7 +128,7 @@
             </RefDoc>
         </Document>
     </MsgHead>
-    <ns3:MottakenhetBlokk ediLoggId="nye-emottak-ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
+    <ns3:MottakenhetBlokk ediLoggId="ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
                       avsenderRef="" avsenderFnrFraDigSignatur="20086600138" mottattDatotid="2026-04-08T00:00:00.000+02:00"
                       ebRole="Lege" ebService="Legemelding" ebAction="Legeerklaring"/>
 </ns3:EI_fellesformat>

--- a/ebms-send-in/src/test/resources/legemeldingV2.xml
+++ b/ebms-send-in/src/test/resources/legemeldingV2.xml
@@ -128,7 +128,7 @@
             </RefDoc>
         </Document>
     </MsgHead>
-    <ns3:MottakenhetBlokk ediLoggId="nye-emottak-ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
+    <ns3:MottakenhetBlokk ediLoggId="ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
                           avsenderRef="" avsenderFnrFraDigSignatur="20086600138" mottattDatotid="2026-04-08T00:00:00.000+02:00"
                           ebRole="Lege" ebService="Legemelding" ebAction="Legeerklaring"/>
 </ns3:EI_fellesformat>

--- a/ebms-send-in/src/test/resources/legemeldingV3.xml
+++ b/ebms-send-in/src/test/resources/legemeldingV3.xml
@@ -128,7 +128,7 @@
             </RefDoc>
         </Document>
     </MsgHead>
-    <MottakenhetBlokk ediLoggId="nye-emottak-ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
+    <MottakenhetBlokk ediLoggId="ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" avsender="12345678910" ebXMLSamtaleId="1234"
                           avsenderRef="" avsenderFnrFraDigSignatur="20086600138" mottattDatotid="2026-04-08T00:00:00.000+02:00"
                         ebAction="Legeerklaring" ebRole="Lege" ebService="Legemelding"/>
 </EI_fellesformat>

--- a/ebms-send-in/src/test/resources/legemeldingV4.xml
+++ b/ebms-send-in/src/test/resources/legemeldingV4.xml
@@ -130,5 +130,5 @@
     </MsgHead>
     <MottakenhetBlokk avsender="12345678910" avsenderFnrFraDigSignatur="20086600138" avsenderRef=""
                       ebAction="Legeerklaring" ebRole="Lege" ebService="Legemelding"
-                      ebXMLSamtaleId="1234" ediLoggId="nye-emottak-ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" mottattDatotid="2026-04-08T00:00:00.000+02:00"/>
+                      ebXMLSamtaleId="1234" ediLoggId="ed63e4e0-6bed-43b1-b99d-74ef5cb2bc47" mottattDatotid="2026-04-08T00:00:00.000+02:00"/>
 </EI_fellesformat>

--- a/ebms-send-in/src/test/resources/legemelding_respons.xml
+++ b/ebms-send-in/src/test/resources/legemelding_respons.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <EI_fellesformat xmlns="http://www.trygdeetaten.no/xml/eiff/1/"
                  xmlns:ns2="http://www.kith.no/xmlstds/apprec/2004-11-21">
-    <MottakenhetBlokk ediLoggId="nye-emottak-2a4a4a1e-f2e7-41af-8db0-83de06d0fda3" ebRole="Nav" ebService="Legemelding"
+    <MottakenhetBlokk ediLoggId="2a4a4a1e-f2e7-41af-8db0-83de06d0fda3" ebRole="Nav" ebService="Legemelding"
                       ebAction="Svarmelding"/>
     <ns2:AppRec>
         <ns2:MsgType V="APPREC"/>


### PR DESCRIPTION
Kan skille gamle/nye ved UUID-format eller ikke